### PR TITLE
fix: Add unique origin entity code

### DIFF
--- a/docs/4.4.1-release-notes.md
+++ b/docs/4.4.1-release-notes.md
@@ -3,3 +3,4 @@
 - Terminology changes
 
 ### Fix
+- Fix Topology not showing data from enricher

--- a/src/ExternalSearch.Providers.libpostal/libpostalExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.libpostal/libpostalExternalSearchProvider.cs
@@ -204,7 +204,8 @@ namespace CluedIn.ExternalSearch.Providers.Libpostal
         {
             if (result is IExternalSearchQueryResult<LibpostalResponse> libpostalResult)
             {
-                var clue = new Clue(request.EntityMetaData.OriginEntityCode, context.Organization);
+                var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "libpostal", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+                var clue = new Clue(code, context.Organization);
                 PopulateMetadata(clue.Data.EntityData, libpostalResult, request);
                 return new[] { clue };
             }
@@ -290,12 +291,15 @@ namespace CluedIn.ExternalSearch.Providers.Libpostal
 
         private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<LibpostalResponse> resultItem, IExternalSearchRequest request)
         {
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "libpostal", $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+
             metadata.EntityType = request.EntityMetaData.EntityType;
 
             //Name is required, without it the changes are ignored and not added to the entity.
             metadata.Name = request.EntityMetaData.Name;
             //metadata.Description = resultItem.Data.description;
-            metadata.OriginEntityCode = request.EntityMetaData.OriginEntityCode;
+            metadata.OriginEntityCode = code;
+            metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
             foreach (var item in resultItem.Data.Items)
             {


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#47706](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/47706)

Topology now showing Libpostal data, but the one from other enricher turn into no source (logo cannot display)
![image](https://github.com/user-attachments/assets/7231df1f-5593-464c-83d1-884e80f0d467)

## How has it been tested? <!-- Remove if not needed -->
Manually in local
