### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>3.2.1</_ComponentHost>
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.6.0</_CluedIn>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
@@ -10,18 +9,13 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
-    <!--    <PackageReference Update="CluedIn.Testing.Base" Version="$(_CluedIn)" />-->
   </ItemGroup>
   <ItemGroup>
     <!--
@@ -29,7 +23,6 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": "false"
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52",

--- a/src/ExternalSearch.Providers.Libpostal.Provider/Provider.ExternalSearch.Libpostal.csproj
+++ b/src/ExternalSearch.Providers.Libpostal.Provider/Provider.ExternalSearch.Libpostal.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />
-    <PackageReference Include="ComponentHost" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExternalSearch.Providers.Libpostal.Provider/Provider.ExternalSearch.Libpostal.csproj
+++ b/src/ExternalSearch.Providers.Libpostal.Provider/Provider.ExternalSearch.Libpostal.csproj
@@ -1,12 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Resources\**" />
     <EmbeddedResource Remove="Resources\**" />

--- a/src/ExternalSearch.Providers.libpostal/ExternalSearch.Providers.libpostal.csproj
+++ b/src/ExternalSearch.Providers.libpostal/ExternalSearch.Providers.libpostal.csproj
@@ -9,7 +9,4 @@
     <PackageReference Include="CluedIn.Core" />
     <PackageReference Include="CluedIn.ExternalSearch" />
   </ItemGroup>
-  <PropertyGroup>
-    <LangVersion>preview</LangVersion>
-  </PropertyGroup>
 </Project>

--- a/src/ExternalSearch.Providers.libpostal/libpostalExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.libpostal/libpostalExternalSearchProvider.cs
@@ -166,13 +166,13 @@ namespace CluedIn.ExternalSearch.Providers.Libpostal
         public IEnumerable<IExternalSearchQueryResult> ExecuteSearch(ExecutionContext context, IExternalSearchQuery query, IDictionary<string, object> config, IProvider provider)
         {
             var url = ConfigurationManagerEx.AppSettings.GetValue("ExternalSearch.Libpostal.url", "");
-            if (url.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(url))
             {
                 throw new Exception("Bad configuration");
             }
 
             var client = new RestClient(url);
-            var request = new RestRequest("parser", Method.POST);
+            var request = new RestRequest("parser", Method.Post);
             string address = null;
             request.AddHeader("Content-type", "application/json");
             if (query.QueryParameters.ContainsKey("body"))
@@ -187,7 +187,7 @@ namespace CluedIn.ExternalSearch.Providers.Libpostal
 
             request.AddJsonBody(new queryBody() { query = address });
 
-            var response = client.ExecuteTaskAsync<LibpostalResponse>(request).Result;
+            var response = client.ExecuteAsync<LibpostalResponse>(request).Result;
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -245,13 +245,13 @@ namespace CluedIn.ExternalSearch.Providers.Libpostal
         public ConnectionVerificationResult VerifyConnection(ExecutionContext context, IReadOnlyDictionary<string, object> config)
         {
             var url = ConfigurationManagerEx.AppSettings.GetValue("ExternalSearch.Libpostal.url", "");
-            if (url.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(url))
             {
                 return new ConnectionVerificationResult(false, "Bad configuration: Invalid url");
             }
 
             var client = new RestClient(url);
-            var request = new RestRequest("parser", Method.POST);
+            var request = new RestRequest("parser", Method.Post);
             var address = "Belgrave House, 76 Buckingham Palace Road";
             request.AddHeader("Content-type", "application/json");
             request.AddJsonBody(new queryBody() { query = address });
@@ -266,7 +266,7 @@ namespace CluedIn.ExternalSearch.Providers.Libpostal
             return ConstructVerifyConnectionResponse(response);
         }
 
-        private ConnectionVerificationResult ConstructVerifyConnectionResponse(IRestResponse response)
+        private ConnectionVerificationResult ConstructVerifyConnectionResponse(RestResponse response)
         {
             var errorMessageBase = $"{Constants.ProviderName} returned \"{(int)response.StatusCode} {response.StatusDescription}\".";
             if (response.ErrorException != null)

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2"/>
+    <PackageReference Include="AutoFixture.Xunit3"/>
     <PackageReference Include="coverlet.msbuild"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.v3"/>
     <PackageReference Include="xunit.runner.visualstudio"/>
     <PackageReference Include="Moq"/>
     <PackageReference Include="Shouldly"/>


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`; `LangVersion` removed (defaults to C# 13)
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`
- Castle.Core extension method removed; `string.IsNullOrEmpty` used directly